### PR TITLE
Fix /libraryapagar "if" condition

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -39,8 +39,8 @@ const deleteLibraryItem = (message) => {
       }
       const { authorId } = doc.data()
       // Pessoa que quer deletar o learning não é o criador
-      // OU não é da diretoria executiva (definido em DIREX_ROLE_ID)
-      if (message.author.id !== authorId || message.member.roles.has(DIREX_ROLE_ID)) {
+      // E não é da diretoria executiva (definido em DIREX_ROLE_ID)
+      if (message.author.id !== authorId && !message.member.roles.has(DIREX_ROLE_ID)) {
         database
           .collection('authors')
           .doc(authorId)


### PR DESCRIPTION
Fixes the condition that checks if the user can delete a learning.

Previously, it was checked if the user wasn't the author OR if the user had superpowers to show the error message.

So, if the user had superpowers, he or she would be shown the message, because the second clause would automatically evaluate the whole if as `true`.

Now, we only show the message if the user isn't the author AND if the user doesn't have superpowers.

If the user is the author, the first clause will fail, so the `if` won't be executed. If the user isn't the author (in other words, the first clause is correct), but he or she has superpowers, the second clause will fail and the if will execute.

I think everybody knows which scenario comes next and why it would show the message :)